### PR TITLE
US-9713 ps4 v2.3.0 app crash

### DIFF
--- a/crypto/bio/socket.c
+++ b/crypto/bio/socket.c
@@ -68,6 +68,7 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
 OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
 #elif defined(OPENSSL_PS4)
 #include <YiPort.h>
+#include <unistd.h>
 #else
 #include <unistd.h>
 #endif

--- a/crypto/bio/socket.c
+++ b/crypto/bio/socket.c
@@ -70,6 +70,10 @@ OPENSSL_MSVC_PRAGMA(warning(pop))
 OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
 #endif
 
+#if defined(OPENSSL_PS4)
+#include <net.h>
+#endif
+
 #include "internal.h"
 
 
@@ -130,6 +134,8 @@ static int sock_write(BIO *b, const char *in, int inl) {
   bio_clear_socket_error();
 #if defined(OPENSSL_WINDOWS)
   ret = send(b->num, in, inl, 0);
+#elif defined(OPENSSL_PS4)
+  ret = sceNetSend(b->num, in, inl, 0)
 #else
   ret = write(b->num, in, inl);
 #endif

--- a/crypto/bio/socket.c
+++ b/crypto/bio/socket.c
@@ -116,7 +116,7 @@ static int sock_read(BIO *b, char *out, int outl) {
 #if defined(OPENSSL_WINDOWS)
   ret = recv(b->num, out, outl, 0);
 #elif defined(OPENSSL_PS4)
-  ret = YiPortReceive(b->num, out, outl, 0);
+  ret = YiNetReceive(b->num, out, outl, 0);
 #else
   ret = read(b->num, out, outl);
 #endif
@@ -136,7 +136,7 @@ static int sock_write(BIO *b, const char *in, int inl) {
 #if defined(OPENSSL_WINDOWS)
   ret = send(b->num, in, inl, 0);
 #elif defined(OPENSSL_PS4)
-  ret = YiPortSend(b->num, in, inl, 0);
+  ret = YiNetSend(b->num, in, inl, 0);
 #else
   ret = write(b->num, in, inl);
 #endif

--- a/crypto/bio/socket.c
+++ b/crypto/bio/socket.c
@@ -60,18 +60,16 @@
 #include <fcntl.h>
 #include <string.h>
 
-#if !defined(OPENSSL_WINDOWS)
-#include <unistd.h>
-#else
+#if defined(OPENSSL_WINDOWS)
 OPENSSL_MSVC_PRAGMA(warning(push, 3))
 #include <winsock2.h>
 OPENSSL_MSVC_PRAGMA(warning(pop))
 
 OPENSSL_MSVC_PRAGMA(comment(lib, "Ws2_32.lib"))
-#endif
-
-#if defined(OPENSSL_PS4)
-#include <net.h>
+#elif defined(OPENSSL_PS4)
+#include <YiPort.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "internal.h"
@@ -116,6 +114,8 @@ static int sock_read(BIO *b, char *out, int outl) {
   bio_clear_socket_error();
 #if defined(OPENSSL_WINDOWS)
   ret = recv(b->num, out, outl, 0);
+#elif defined(OPENSSL_PS4)
+  ret = YiPortReceive(b->num, out, outl, 0);
 #else
   ret = read(b->num, out, outl);
 #endif
@@ -135,7 +135,7 @@ static int sock_write(BIO *b, const char *in, int inl) {
 #if defined(OPENSSL_WINDOWS)
   ret = send(b->num, in, inl, 0);
 #elif defined(OPENSSL_PS4)
-  ret = sceNetSend(b->num, in, inl, 0);
+  ret = YiPortSend(b->num, in, inl, 0);
 #else
   ret = write(b->num, in, inl);
 #endif

--- a/crypto/bio/socket.c
+++ b/crypto/bio/socket.c
@@ -135,7 +135,7 @@ static int sock_write(BIO *b, const char *in, int inl) {
 #if defined(OPENSSL_WINDOWS)
   ret = send(b->num, in, inl, 0);
 #elif defined(OPENSSL_PS4)
-  ret = sceNetSend(b->num, in, inl, 0)
+  ret = sceNetSend(b->num, in, inl, 0);
 #else
   ret = write(b->num, in, inl);
 #endif


### PR DESCRIPTION
App "crashes" because it receives a SIGPIPE signal and the default behaviour. To fix this we must use PS4's API to avoid it.

Note start from db74878. Fixed suggestions that were mentioned.